### PR TITLE
Attach scanned receipt image to Firefly III transaction

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import sys
 
@@ -107,8 +108,18 @@ async def create_transaction(
     category: str = Form(...),
     budget: str = Form(...),
     source_account: str = Form(...),
+    attach_receipt: str = Form(""),
+    image_base64: str = Form(""),
 ):
     try:
+        # Decode image bytes if attachment is requested
+        image_bytes = None
+        if attach_receipt and image_base64:
+            try:
+                image_bytes = base64.b64decode(image_base64)
+            except Exception as e:
+                print(f"Warning: Failed to decode image for attachment: {e}")
+
         # Create the transaction
         result = await create_transaction_from_data(
             {
@@ -121,6 +132,8 @@ async def create_transaction(
                 "source_account": source_account,
             },
             source_account,
+            image_bytes=image_bytes,
+            filename=f"receipt_{store_name}_{date}.jpg",
         )
 
         if result and "Failed to create transaction" in result:

--- a/app/firefly.py
+++ b/app/firefly.py
@@ -165,3 +165,40 @@ def create_firefly_transaction(receipt, source_account="Cash wallet"):
     except requests.exceptions.RequestException as e:
         print(f"Error creating transaction: {e}")
         raise Exception(f"Error communicating with Firefly III: {str(e)}")
+
+
+def attach_image_to_transaction(
+    transaction_journal_id: int, image_bytes: bytes, filename: str
+):
+    """Attach an image to a Firefly III transaction journal."""
+    settings = get_settings()
+    headers = {
+        "Authorization": f"Bearer {settings.firefly_iii_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    # Step 1: Create the attachment metadata
+    url = urljoin(settings.firefly_api_url, "attachments")
+    payload = {
+        "filename": filename,
+        "attachable_type": "TransactionJournal",
+        "attachable_id": transaction_journal_id,
+    }
+
+    response = requests.post(url, headers=headers, json=payload, timeout=TIMEOUT)
+    response.raise_for_status()
+    attachment_id = response.json()["data"]["id"]
+
+    # Step 2: Upload the image bytes
+    upload_url = urljoin(settings.firefly_api_url, f"attachments/{attachment_id}/upload")
+    upload_headers = {
+        "Authorization": f"Bearer {settings.firefly_iii_token}",
+        "Content-Type": "application/octet-stream",
+    }
+
+    response = requests.post(
+        upload_url, headers=upload_headers, data=image_bytes, timeout=TIMEOUT
+    )
+    response.raise_for_status()
+    print(f"Attachment {attachment_id} uploaded for journal {transaction_journal_id}")

--- a/app/image_utils.py
+++ b/app/image_utils.py
@@ -14,7 +14,7 @@ async def process_image(file: UploadFile, max_size=(768, 768)):
         quality: JPEG quality (1-100) for compression
 
     Returns:
-        A tuple containing (base64_encoded_image, original_filename)
+        A tuple containing (PIL.Image, original_file_bytes)
     """
     # Read the uploaded file
     contents = await file.read()
@@ -29,4 +29,4 @@ async def process_image(file: UploadFile, max_size=(768, 768)):
     # Resize the image while maintaining aspect ratio
     img.thumbnail(max_size, Image.LANCZOS)
 
-    return img
+    return img, contents

--- a/app/receipt_processing.py
+++ b/app/receipt_processing.py
@@ -1,3 +1,4 @@
+import base64
 import time
 from datetime import datetime
 from functools import lru_cache
@@ -7,6 +8,7 @@ from google import genai
 
 from .config import get_settings
 from .firefly import (
+    attach_image_to_transaction,
     create_firefly_transaction,
     get_firefly_budgets,
     get_firefly_categories,
@@ -27,7 +29,7 @@ async def extract_receipt_data(file: UploadFile):
         print(f"Processing image: {file.filename}")
 
         # Process the image (resize and compress with more aggressive settings)
-        image = await process_image(file, max_size=(768, 768))
+        image, image_bytes = await process_image(file, max_size=(768, 768))
         print("Image processed and encoded to base64")
 
         # Fetch dynamic data from Firefly III
@@ -122,6 +124,7 @@ async def extract_receipt_data(file: UploadFile):
             "budget": gemini_response.parsed.budget,
             "available_categories": categories,
             "available_budgets": budgets,
+            "image_base64": base64.b64encode(image_bytes).decode("utf-8"),
         }
         print("Successfully extracted all data")
         return extracted_data
@@ -131,7 +134,9 @@ async def extract_receipt_data(file: UploadFile):
         raise
 
 
-async def create_transaction_from_data(receipt_data, source_account):
+async def create_transaction_from_data(
+    receipt_data, source_account, image_bytes=None, filename="receipt.jpg"
+):
     """Create a transaction in Firefly III using the provided data."""
     # Create a ReceiptModel object from the data
     receipt = ReceiptModel(
@@ -162,6 +167,24 @@ async def create_transaction_from_data(receipt_data, source_account):
                 print(f"- Budget: {receipt.budget}")
                 print(f"- Source Account: {source_account}")
                 print(f"- Transaction ID: {transaction_result['data']['id']}")
+
+                # Attach image if provided
+                if image_bytes:
+                    try:
+                        journal_id = int(
+                            transaction_result["data"]["attributes"][
+                                "transactions"
+                            ][0]["transaction_journal_id"]
+                        )
+                        attach_image_to_transaction(
+                            journal_id, image_bytes, filename
+                        )
+                        print("Receipt image attached to transaction")
+                    except Exception as e:
+                        print(
+                            f"Warning: Failed to attach receipt image: {e}"
+                        )
+
                 return f"Transaction created successfully with ID: {transaction_result['data']['id']}"
             else:
                 last_error = (

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -81,6 +81,32 @@ input:focus, select:focus {
     background: #7f8c8d;
 }
 
+.checkbox-group {
+    display: flex;
+    align-items: center;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    font-weight: 500;
+    color: #2c3e50;
+    margin-bottom: 0;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    accent-color: #3498db;
+}
+
+.checkbox-label span {
+    font-size: 16px;
+}
+
 .error {
     background: #ffebee;
     color: #c62828;

--- a/app/templates/review.html
+++ b/app/templates/review.html
@@ -46,7 +46,16 @@
     </div>
     
     <input type="hidden" name="source_account" value="{{ extracted_data.source_account }}">
-    
+    <input type="hidden" name="image_base64" value="{{ extracted_data.image_base64 }}">
+
+    <div class="form-group checkbox-group">
+        <label class="checkbox-label">
+            <input type="checkbox" id="attach_receipt_checkbox" checked>
+            <span>Attach receipt to transaction</span>
+        </label>
+        <input type="hidden" name="attach_receipt" id="attach_receipt_value" value="on">
+    </div>
+
     <div class="form-group">
         <button type="submit" id="submit-btn" class="btn">Create Transaction</button>
         <button type="button" class="btn btn-secondary" onclick="window.location.href='/'">Cancel</button>
@@ -65,5 +74,9 @@
         document.getElementById('loading').classList.add('active');
         document.getElementById('submit-btn').disabled = true;
     }
+
+    document.getElementById('attach_receipt_checkbox').addEventListener('change', function() {
+        document.getElementById('attach_receipt_value').value = this.checked ? 'on' : '';
+    });
 </script>
 {% endblock %} 


### PR DESCRIPTION
## Summary
- Carry original image bytes through the extraction flow and pass them to the review form as base64 in a hidden field
- Add an "Attach receipt to transaction" checkbox (checked by default) on the review form
- After transaction creation, upload the receipt image as an attachment to the Firefly III transaction journal via the attachments API
- Attachment failure logs a warning but does not fail the transaction

## Changes
- **`image_utils.py`** — `process_image` now returns `(PIL.Image, bytes)` tuple
- **`receipt_processing.py`** — base64-encodes image bytes into `extracted_data`; `create_transaction_from_data` accepts optional `image_bytes` and
 calls `attach_image_to_transaction` on success
- **`firefly.py`** — new `attach_image_to_transaction` function (creates attachment metadata then uploads raw bytes)
- **`review.html`** — hidden image field + checkbox with JS sync
- **`app.py`** — accepts `attach_receipt` and `image_base64` form fields, decodes and passes to transaction logic
- **`styles.css`** — checkbox styling

Closes #7

## Test plan
- [ ] Upload a receipt → verify the review form shows the "Attach receipt" checkbox (checked by default)
- [ ] Submit with checkbox checked → verify transaction is created AND receipt appears as attachment in Firefly III
- [ ] Submit with checkbox unchecked → verify transaction is created WITHOUT an attachment
- [ ] Check container logs for any attachment-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)